### PR TITLE
Import dillo-3.1.0 as www/dillo-cxx98

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -103,6 +103,7 @@ SUBDIR+=	davical
 SUBDIR+=	ddgr
 SUBDIR+=	deforaos-surfer
 SUBDIR+=	dillo
+SUBDIR+=	dillo-cxx98
 SUBDIR+=	drraw
 SUBDIR+=	drupal7
 SUBDIR+=	drupal9

--- a/www/dillo-cxx98/DESCR
+++ b/www/dillo-cxx98/DESCR
@@ -1,0 +1,1 @@
+A very small and fast graphical web browser using FLTK-1.3.

--- a/www/dillo-cxx98/Makefile
+++ b/www/dillo-cxx98/Makefile
@@ -1,0 +1,50 @@
+# $NetBSD: Makefile,v 1.91 2024/05/11 12:07:13 nia Exp $
+
+DISTNAME=	dillo-3.1.0
+CATEGORIES=	www
+MASTER_SITES=	${MASTER_SITE_GITHUB:=dillo-browser/}
+GITHUB_TAG=	v${PKGVERSION_NOREV}
+
+MAINTAINER=	pkgsrc-users@NetBSD.org
+HOMEPAGE=	https://dillo-browser.github.io/
+COMMENT=	Very small and fast graphical web-browser
+LICENSE=	gnu-gpl-v3
+
+USE_LANGUAGES=		c c++
+GNU_CONFIGURE=		yes
+CONFIGURE_ARGS+=	--sysconfdir=${PKG_SYSCONFBASEDIR}
+
+REPLACE_PERL+=	dillo-install-hyphenation
+USE_TOOLS+=	perl:run wget:run
+
+PKG_SYSCONFSUBDIR=	dillo
+EGDIR=			${PREFIX}/share/examples/dillo
+CONF_FILES=		${EGDIR}/dillorc ${PKG_SYSCONFDIR}/dillorc
+CONF_FILES+=		${EGDIR}/dpidrc ${PKG_SYSCONFDIR}/dpidrc
+CONF_FILES+=		${EGDIR}/keysrc ${PKG_SYSCONFDIR}/keysrc
+CONF_FILES+=		${EGDIR}/domainrc ${PKG_SYSCONFDIR}/domainrc
+
+INSTALLATION_DIRS=	share/doc/dillo ${EGDIR}
+
+INSTALL_MAKE_FLAGS+=	sysconfdir=${EGDIR}
+
+USE_TOOLS+=		aclocal autoconf automake autoreconf gmake perl tar
+
+.include "options.mk"
+
+pre-configure:
+	cd ${WRKSRC} && autoreconf -fi
+
+post-install:
+	${INSTALL_DATA} ${WRKSRC}/doc/*.txt ${DESTDIR}${PREFIX}/share/doc/dillo
+	${INSTALL_DATA} ${WRKSRC}/doc/README ${DESTDIR}${PREFIX}/share/doc/dillo
+
+.include "../../converters/libiconv/buildlink3.mk"
+.include "../../devel/zlib/buildlink3.mk"
+.include "../../graphics/hicolor-icon-theme/buildlink3.mk"
+.include "../../graphics/png/buildlink3.mk"
+.include "../../mk/jpeg.buildlink3.mk"
+.include "../../x11/fltk13/buildlink3.mk"
+
+.include "../../mk/pthread.buildlink3.mk"
+.include "../../mk/bsd.pkg.mk"

--- a/www/dillo-cxx98/PLIST
+++ b/www/dillo-cxx98/PLIST
@@ -1,0 +1,25 @@
+@comment $NetBSD: PLIST,v 1.20 2024/05/07 18:06:35 abs Exp $
+bin/dillo
+bin/dillo-install-hyphenation
+bin/dpid
+bin/dpidc
+lib/dillo/dpi/bookmarks/bookmarks.dpi
+lib/dillo/dpi/cookies/cookies.dpi
+lib/dillo/dpi/datauri/datauri.filter.dpi
+lib/dillo/dpi/downloads/downloads.dpi
+lib/dillo/dpi/file/file.dpi
+lib/dillo/dpi/ftp/ftp.filter.dpi
+lib/dillo/dpi/hello/hello.filter.dpi
+lib/dillo/dpi/vsource/vsource.filter.dpi
+man/man1/dillo.1
+share/applications/dillo.desktop
+share/doc/dillo/Cookies.txt
+share/doc/dillo/README
+share/doc/dillo/user_help.html
+share/examples/dillo/dillorc
+share/examples/dillo/domainrc
+share/examples/dillo/dpidrc
+share/examples/dillo/hsts_preload
+share/examples/dillo/keysrc
+share/icons/hicolor/128x128/apps/dillo.png
+share/icons/hicolor/48x48/apps/dillo.png

--- a/www/dillo-cxx98/distinfo
+++ b/www/dillo-cxx98/distinfo
@@ -1,0 +1,5 @@
+$NetBSD: distinfo,v 1.43 2024/05/07 18:06:35 abs Exp $
+
+BLAKE2s (dillo-3.1.0.tar.gz) = e15d9a6dafa97a6140047df208647e46675a8fa93f3eb287ff81b77fb150064f
+SHA512 (dillo-3.1.0.tar.gz) = c34995a9b7911458f962b1f7424a06a4b95ad8a3f01a3e84ecbf19fa6e6fd10992c5536712e4942ab45b2137e543e1d383751ffc50b58f95d4da9f5891d05c61
+Size (dillo-3.1.0.tar.gz) = 1514218 bytes

--- a/www/dillo-cxx98/options.mk
+++ b/www/dillo-cxx98/options.mk
@@ -1,0 +1,26 @@
+# $NetBSD: options.mk,v 1.7 2024/05/07 18:06:35 abs Exp $
+
+PKG_OPTIONS_VAR=	PKG_OPTIONS.dillo
+PKG_SUPPORTED_OPTIONS=	inet6 ssl
+PKG_SUGGESTED_OPTIONS=	inet6 ssl
+
+.include "../../mk/bsd.options.mk"
+
+.if !empty(PKG_OPTIONS:Minet6)
+CONFIGURE_ARGS+=	--enable-ipv6
+.endif
+
+.if !empty(PKG_OPTIONS:Mssl)
+CONFIGURE_ARGS+=	--enable-tls
+LIBS+=			-lssl
+.include "../../security/openssl/buildlink3.mk"
+
+SUBST_CLASSES+=		sslcerts
+SUBST_MESSAGE.sslcerts=	Fixing SSL certificate directory.
+SUBST_FILES.sslcerts=	src/IO/tls_openssl.c src/IO/tls_mbedtls.c
+SUBST_STAGE.sslcerts=	post-extract
+SUBST_SED.sslcerts=	-e 's,"/etc/ssl/certs,"${SSLCERTS},'
+
+.else
+CONFIGURE_ARGS+=	--disable-ssl
+.endif


### PR DESCRIPTION
This is the last version that builds without a C++11 compiler.

Tested on:

Darwin 10.4 PowerPC
NetBSD 10.1 amd64