### PR TITLE
libcaca: Update to 0.99.20

### DIFF
--- a/graphics/libcaca/Makefile
+++ b/graphics/libcaca/Makefile
@@ -1,10 +1,10 @@
 # $NetBSD: Makefile,v 1.41 2024/05/06 08:40:27 jperkin Exp $
 
-DISTNAME=	libcaca-0.99.beta19
+DISTNAME=	libcaca-0.99.beta20
 PKGNAME=	${DISTNAME:S/beta//}
-PKGREVISION=	4
 CATEGORIES=	graphics
-MASTER_SITES=	http://caca.zoy.org/files/libcaca/
+MASTER_SITES=	${MASTER_SITE_GITHUB:=cacalabs/}
+GITHUB_RELEASE=	v0.99.beta20
 
 MAINTAINER=	pkgsrc-users@NetBSD.org
 HOMEPAGE=	http://caca.zoy.org/
@@ -30,4 +30,5 @@ CONFIGURE_ARGS+=	--disable-doc
 LDFLAGS.Linux+=	-ldl
 LDFLAGS.SunOS+=	-lsocket -lnsl
 
+.include "../../graphics/imlib2/buildlink3.mk"
 .include "../../mk/bsd.pkg.mk"

--- a/graphics/libcaca/distinfo
+++ b/graphics/libcaca/distinfo
@@ -1,7 +1,9 @@
 $NetBSD: distinfo,v 1.12 2021/10/26 10:46:25 nia Exp $
 
-BLAKE2s (libcaca-0.99.beta19.tar.gz) = a108af0018fdbc72e4e34e45f26b09a13df511b13f128ba13a125de97cc1b23d
-SHA512 (libcaca-0.99.beta19.tar.gz) = 780fc7684d40207cc10df3f87d6d8f1d47ddfffa0e76e41a5ce671b82d5c7f090facb054c3d49ca7c4ea1a619625bb9085ce52f837f50792b4a2d776a4c68e15
-Size (libcaca-0.99.beta19.tar.gz) = 1203495 bytes
+BLAKE2s (libcaca-0.99.beta20.tar.gz) = a876fb9691d30c2aea3ecff525205feb8ff612e05ecd71532f9884a3d0ce24cc
+SHA512 (libcaca-0.99.beta20.tar.gz) = ab03e6c7d17fd152b2d5e9161799531f5e87322e174cb9d25874700f5bc1acfaf8bc2736e733998dad906f793c5a0304740dd39eec04a5e4c3d181bb109b4f23
+Size (libcaca-0.99.beta20.tar.gz) = 1099916 bytes
+SHA1 (patch-CVE-2022-0856) = 466b2e6abf21cd28d0195a72f382be57aaee1d4d
 SHA1 (patch-caca_dither.c) = d2285e75eaec09840c38c2c54ce5e942d0a2e820
+SHA1 (patch-configure) = 12b3f5c5835876e9e26df7ce677182548bf36572
 SHA1 (patch-examples_font.c) = cc3e32a41c941e2c11a380e4e811ac4ba8b14f1d

--- a/graphics/libcaca/options.mk
+++ b/graphics/libcaca/options.mk
@@ -1,19 +1,11 @@
 # $NetBSD: options.mk,v 1.7 2024/05/06 08:33:51 jperkin Exp $
 
 PKG_OPTIONS_VAR=		PKG_OPTIONS.libcaca
-PKG_SUPPORTED_OPTIONS=		imlib2
 PKG_OPTIONS_REQUIRED_GROUPS=	driver
 PKG_OPTIONS_GROUP.driver=	ncurses slang x11
 PKG_SUGGESTED_OPTIONS=		ncurses
 
 .include "../../mk/bsd.options.mk"
-
-.if !empty(PKG_OPTIONS:Mimlib2)
-.  include "../../graphics/imlib2/buildlink3.mk"
-CONFIGURE_ARGS+=	--enable-imlib2
-.else
-CONFIGURE_ARGS+=	--disable-imlib2
-.endif
 
 .if !empty(PKG_OPTIONS:Mncurses)
 .  include "../../devel/ncurses/buildlink3.mk"

--- a/graphics/libcaca/patches/patch-CVE-2022-0856
+++ b/graphics/libcaca/patches/patch-CVE-2022-0856
@@ -1,0 +1,32 @@
+$NetBSD$
+
+[PATCH] Prevent a divide-by-zero by checking for a zero width or height.
+
+https://github.com/cacalabs/libcaca/pull/66
+
+--- src/img2txt.c.orig	2018-05-22 14:04:36.000000000 +0000
++++ src/img2txt.c
+@@ -177,7 +177,13 @@ int main(int argc, char **argv)
+     }
+ 
+     /* Assume a 6×10 font */
+-    if(!cols && !lines)
++    if(!i->w || !i->h)
++    {
++	fprintf(stderr, "%s: image size is 0\n", argv[0]);
++        lines = 0;
++	cols = 0;
++    }
++    else if(!cols && !lines)
+     {
+         cols = 60;
+         lines = cols * i->h * font_width / i->w / font_height;
+@@ -214,7 +220,7 @@ int main(int argc, char **argv)
+     export = caca_export_canvas_to_memory(cv, format?format:"ansi", &len);
+     if(!export)
+     {
+-        fprintf(stderr, "%s: Can't export to format '%s'\n", argv[0], format);
++        fprintf(stderr, "%s: Can't export to format '%s'\n", argv[0], format?format:"ansi");
+     }
+     else
+     {

--- a/graphics/libcaca/patches/patch-configure
+++ b/graphics/libcaca/patches/patch-configure
@@ -1,0 +1,26 @@
+$NetBSD$
+
+[PATCH] Remove bashism in configure.ac
+
+Patch courtesy of Jakub Bogusz.
+
+https://github.com/cacalabs/libcaca/commit/9a0ebef8d7d78bd32737ba45afc28d260fd1616b.patch
+
+--- configure.orig	2025-02-17 20:32:40.574425308 +0000
++++ configure
+@@ -19422,7 +19422,6 @@ fi
+ done
+   CFLAGS="$save_CFLAGS"
+   if test "${ac_cv_my_have_cocoa}" = "yes"; then
+-    [[ "$target_os" =~ [0-9]+ ]] && darwin_ver="${BASH_REMATCH[0]}"
+     case x${target} in
+     xpowerpc*darwin*)
+       # 10.3 needed to link with X11
+@@ -19450,6 +19449,7 @@ done
+     esac
+     CC="${CC:-gcc-${GCC_VERSION}}"
+     CXX="${CXX:-g++-${GCC_VERSION}}"
++    darwin_ver="$(echo "${target_os}" | sed -ne 's/[^0-9]*\([0-9]\+\).*/\1/p')"
+     if [ "$darwin_ver" -lt "13" ]; then
+       MACOSX_SDK_FRAMEWORKS="${MACOSX_SDK_FRAMEWORKS:--F${MACOSX_SDK}/System/Library/Frameworks}"
+       CPPFLAGS="${CPPFLAGS} ${ARCH} ${MACOSX_SDK_FRAMEWORKS}"


### PR DESCRIPTION
Special notes:
- building without imlib2 is broken upstream, remove the option. This is not important for the library, just some included tools.
- upstream switched to github.

Upstream changes:
- IPv6 support in cacaserver
- fixed a bug from 2004 that caused PDF documentation generation to fail
- memory allocation functions are now more robust
- numerous fixes for memory leaks and invalid memory accesses: CVE-2021-30498 CVE-2021-30499 CVE-2021-3410 CVE-2018-20546 CVE-2018-20547 CVE-2018-20545 CVE-2018-20548 CVE-2018-20549