### PR TITLE
openssh: Update to 9.9p2

### DIFF
--- a/security/openssh/Makefile
+++ b/security/openssh/Makefile
@@ -1,6 +1,6 @@
 # $NetBSD: Makefile,v 1.286 2024/09/24 21:43:13 wiz Exp $
 
-DISTNAME=		openssh-9.9p1
+DISTNAME=		openssh-9.9p2
 CATEGORIES=		security
 MASTER_SITES=		${MASTER_SITE_OPENBSD:=OpenSSH/portable/}
 
@@ -65,6 +65,8 @@ CONFIGURE_ARGS+=	--with-pie
 # linker directly results in undefined symbols for obvious reasons.
 #
 CONFIGURE_ENV+=		LD=${CC:Q}
+
+CONFIGURE_ENV+=		VARBASE=${VARBASE}
 
 # Enable S/Key support on NetBSD, Darwin, and Solaris.
 .if (${OPSYS} == "NetBSD") || (${OPSYS} == "Darwin") || (${OPSYS} == "SunOS")

--- a/security/openssh/distinfo
+++ b/security/openssh/distinfo
@@ -1,9 +1,9 @@
 $NetBSD: distinfo,v 1.125 2024/09/24 21:43:13 wiz Exp $
 
-BLAKE2s (openssh-9.9p1.tar.gz) = 915490e437430a87ec8077f062c195e9eb7da2455f5cd035f541a9f81d43ff70
-SHA512 (openssh-9.9p1.tar.gz) = 3cc0ed97f3e29ecbd882eca79239f02eb5a1606fce4f3119ddc3c5e86128aa3ff12dc85000879fccc87b60e7d651cfe37376607ac66075fede2118deaa685d6d
-Size (openssh-9.9p1.tar.gz) = 1964864 bytes
-SHA1 (patch-Makefile.in) = 38df2aa7aaeeaac660763724188852bdb8bdcd24
-SHA1 (patch-configure.ac) = eb759d065e296a5fdf1e8925308e6e77ea2c60a8
-SHA1 (patch-defines.h) = 5424b1b24f1d4bbd47efa614ee180a45e7b9a54e
+BLAKE2s (openssh-9.9p2.tar.gz) = 6a453c920f5aa087d39c2978ca14cfb6bd4915fbf3801b7cd395be7f2b018f86
+SHA512 (openssh-9.9p2.tar.gz) = 4c6d839aa3189cd5254c745f2bd51cd3f468b02f8e427b8d7a16b9ad017888a41178d2746dc51fb2d3fec5be00e54b9ab7c32c472ca7dec57a1dea4fc9840278
+Size (openssh-9.9p2.tar.gz) = 1944499 bytes
+SHA1 (patch-Makefile.in) = c57cd6073be30451c66d45cb994615fcc8482462
+SHA1 (patch-configure.ac) = ee2174cc28f296c265ba63aec1bdaf8d0b9f2359
+SHA1 (patch-defines.h) = 31f5d1601eb40e6ce13af5bb2b29b2dd3ddc8a89
 SHA1 (patch-sshkey.h) = aaaf622f377e455c49683fcc2ca42576ccd097bb

--- a/security/openssh/patches/patch-Makefile.in
+++ b/security/openssh/patches/patch-Makefile.in
@@ -1,10 +1,10 @@
-$NetBSD: patch-Makefile.in,v 1.8 2024/07/01 09:19:40 wiz Exp $
+$NetBSD$
 
 Use askpass provided by pkgsrc.
 
 Removed install-sysconf as we handle that phase through post-install
 
---- Makefile.in.orig	2024-07-01 04:36:28.000000000 +0000
+--- Makefile.in.orig	2025-02-18 08:15:08.000000000 +0000
 +++ Makefile.in
 @@ -21,7 +21,7 @@ abs_top_builddir=@abs_top_builddir@
  DESTDIR=
@@ -15,7 +15,7 @@ Removed install-sysconf as we handle that phase through post-install
  SFTP_SERVER=$(libexecdir)/sftp-server
  SSH_KEYSIGN=$(libexecdir)/ssh-keysign
  SSHD_SESSION=$(libexecdir)/sshd-session
-@@ -389,7 +390,7 @@ distprep: catman-do depend-check
+@@ -389,7 +389,7 @@ distprep: catman-do depend-check
  	-rm -rf autom4te.cache .depend.bak
  
  install: $(CONFIGFILES) $(MANPAGES) $(TARGETS) install-files install-sysconf host-key check-config

--- a/security/openssh/patches/patch-configure.ac
+++ b/security/openssh/patches/patch-configure.ac
@@ -1,6 +1,10 @@
-$NetBSD: patch-configure.ac,v 1.10 2024/07/01 09:19:40 wiz Exp $
+$NetBSD$
 
---- configure.ac.orig	2024-07-01 04:36:28.000000000 +0000
+Do not force through rpath settings, let rpath handle them.
+
+Use askpass provided by pkgsrc.
+
+--- configure.ac.orig	2025-02-18 08:15:08.000000000 +0000
 +++ configure.ac
 @@ -380,6 +380,9 @@ AC_ARG_WITH([rpath],
  	]
@@ -12,12 +16,12 @@ $NetBSD: patch-configure.ac,v 1.10 2024/07/01 09:19:40 wiz Exp $
  # Allow user to specify flags
  AC_ARG_WITH([cflags],
  	[  --with-cflags           Specify additional flags to pass to compiler],
-@@ -5568,9 +5628,17 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+@@ -5578,9 +5581,17 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
  ])
  if test -z "$conf_wtmpx_location"; then
  	if test x"$system_wtmpx_path" = x"no" ; then
 -		AC_DEFINE([DISABLE_WTMPX])
-+		for f in /var/log/wtmpx; do
++		for f in ${VARBASE}/log/wtmpx; do
 +			if test -f $f ; then
 +				conf_wtmpx_location=$f
 +			fi
@@ -32,7 +36,7 @@ $NetBSD: patch-configure.ac,v 1.10 2024/07/01 09:19:40 wiz Exp $
  	AC_DEFINE_UNQUOTED([CONF_WTMPX_FILE], ["$conf_wtmpx_location"],
  		[Define if you want to specify the path to your wtmpx file])
  fi
-@@ -5677,7 +5745,7 @@ echo "OpenSSH has been configured with t
+@@ -5687,7 +5698,7 @@ echo "OpenSSH has been configured with t
  echo "                     User binaries: $B"
  echo "                   System binaries: $C"
  echo "               Configuration files: $D"

--- a/security/openssh/patches/patch-defines.h
+++ b/security/openssh/patches/patch-defines.h
@@ -1,10 +1,10 @@
-$NetBSD: patch-defines.h,v 1.5 2024/07/01 09:19:40 wiz Exp $
+$NetBSD$
 
 Define ROOTUID, UTMPX_FILE and WTMPX_FILE
 
---- defines.h.orig	2015-08-21 04:49:03.000000000 +0000
+--- defines.h.orig	2025-02-18 08:15:08.000000000 +0000
 +++ defines.h
-@@ -721,6 +730,24 @@ struct winsize {
+@@ -821,6 +821,24 @@ struct winsize {
  #    endif
  #  endif
  #endif


### PR DESCRIPTION
While here, delint the package. Remove a hardcoded use of /var.

This release fixes two security bugs, including a DoS and MITM impersonator when the VerifyHostKeyDNS option is enabled.