### PR TITLE
 bochs: Enable e1000 ethernet support. 

### DIFF
--- a/emulators/bochs/Makefile
+++ b/emulators/bochs/Makefile
@@ -1,7 +1,7 @@
 # $NetBSD: Makefile,v 1.113 2024/11/17 07:15:51 wiz Exp $
 
 DISTNAME=		bochs-2.7
-PKGREVISION=		6
+PKGREVISION=		7
 CATEGORIES=		emulators
 MASTER_SITES=		${MASTER_SITE_SOURCEFORGE:=bochs/}
 
@@ -47,6 +47,7 @@ CONFIGURE_ARGS+=	--enable-configurable-msrs
 CONFIGURE_ARGS+=	--enable-all-optimizations
 #CONFIGURE_ARGS+=	--enable-instrumentation
 CONFIGURE_ARGS+=	--enable-clgd54xx
+CONFIGURE_ARGS+=	--enable-e1000
 CONFIGURE_ARGS+=	--enable-voodoo
 CONFIGURE_ARGS+=	--enable-fpu
 CONFIGURE_ARGS+=	--enable-vmx=2

--- a/emulators/bochs/PLIST
+++ b/emulators/bochs/PLIST
@@ -7,6 +7,7 @@ lib/bochs/plugins/libbx_biosdev.la
 lib/bochs/plugins/libbx_busmouse.la
 lib/bochs/plugins/libbx_cmos.la
 lib/bochs/plugins/libbx_dma.la
+lib/bochs/plugins/libbx_e1000.la
 lib/bochs/plugins/libbx_es1370.la
 lib/bochs/plugins/libbx_eth_null.la
 lib/bochs/plugins/libbx_eth_slirp.la


### PR DESCRIPTION
This is basically required for networking on any halfway modern OS.