### PR TITLE
exim: Update to  4.98.1

### DIFF
--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -1,7 +1,6 @@
 # $NetBSD: Makefile,v 1.207 2024/11/14 22:20:35 wiz Exp $
 
-DISTNAME=	exim-4.98
-PKGREVISION=	3
+DISTNAME=	exim-4.98.1
 CATEGORIES=	mail net
 MASTER_SITES=	https://ftp.exim.org/pub/exim/exim4/
 MASTER_SITES+=	https://ftp.exim.org/pub/exim/exim4/fixes/
@@ -19,7 +18,7 @@ CONFLICTS+=	exim-exiscan-[0-9]*
 DEPENDS+=	p5-File-FcntlLock>=0.22:../../sysutils/p5-File-FcntlLock
 
 USE_TOOLS+=	perl:run
-USE_LANGUAGES=	c99
+FORCE_C_STD=	gnu89
 
 BUILD_DEFS+=	VARBASE
 

--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -18,7 +18,7 @@ CONFLICTS+=	exim-exiscan-[0-9]*
 DEPENDS+=	p5-File-FcntlLock>=0.22:../../sysutils/p5-File-FcntlLock
 
 USE_TOOLS+=	perl:run
-FORCE_C_STD=	gnu89
+FORCE_C_STD=	c99
 
 BUILD_DEFS+=	VARBASE
 

--- a/mail/exim/Makefile
+++ b/mail/exim/Makefile
@@ -18,7 +18,7 @@ CONFLICTS+=	exim-exiscan-[0-9]*
 DEPENDS+=	p5-File-FcntlLock>=0.22:../../sysutils/p5-File-FcntlLock
 
 USE_TOOLS+=	perl:run
-FORCE_C_STD=	c99
+FORCE_C_STD=	gnu99
 
 BUILD_DEFS+=	VARBASE
 

--- a/mail/exim/distinfo
+++ b/mail/exim/distinfo
@@ -3,8 +3,8 @@ $NetBSD: distinfo,v 1.88 2024/07/12 07:04:45 adam Exp $
 BLAKE2s (exim-4.98.1.tar.xz) = c9ce59e4890cc8869b528b3335f4003291318c8f993139b4a082f1833406f601
 SHA512 (exim-4.98.1.tar.xz) = 8f80999a41ed40e86ee16eea5cfd765e2f164ea149f40eeb410fd02fcf35c23317dc69540efe336e9e0fae930b1cc6771e0180dd70f1314531cdb139740c744e
 Size (exim-4.98.1.tar.xz) = 1928540 bytes
-SHA1 (patch-Local_Makefile.pkgsrc) = 7d6971cfe6f6fecf854926e90460b1a8bcd6a79d
-SHA1 (patch-OS_Makefile-Default) = 6af17f036ed02a3bc37c1f303269eea447fcb691
+SHA1 (patch-Local_Makefile.pkgsrc) = d9d2296bb5345f0f814b5616af32d2157e29f2aa
+SHA1 (patch-OS_Makefile-Default) = 32681d5114eef2da1f624127655edfdeaaa68d64
 SHA1 (patch-lookups_Makefile) = cfc40dba3f75ef37b9887f7767139ad50cf9d4e5
 SHA1 (patch-scripts_exim__install) = aa0a31e77d5f76e33bc92140c14d39c79f710b95
 SHA1 (patch-src_exicyclog.src) = cea5f04f52c9264fd7d279c046686dac2dc57a65

--- a/mail/exim/distinfo
+++ b/mail/exim/distinfo
@@ -1,8 +1,8 @@
 $NetBSD: distinfo,v 1.88 2024/07/12 07:04:45 adam Exp $
 
-BLAKE2s (exim-4.98.tar.xz) = bc37235d4f0250a7a806671bedc6b64888810f2d22334983386639d76e573d54
-SHA512 (exim-4.98.tar.xz) = 13dd963dd0899bb4d64bee44c20883e720e469a4d77456b877d6693cfc4419805a045cb561508cdf763dbb37cc84fbdc6177d68acc2183934c3224fbd03caf15
-Size (exim-4.98.tar.xz) = 1936984 bytes
+BLAKE2s (exim-4.98.1.tar.xz) = c9ce59e4890cc8869b528b3335f4003291318c8f993139b4a082f1833406f601
+SHA512 (exim-4.98.1.tar.xz) = 8f80999a41ed40e86ee16eea5cfd765e2f164ea149f40eeb410fd02fcf35c23317dc69540efe336e9e0fae930b1cc6771e0180dd70f1314531cdb139740c744e
+Size (exim-4.98.1.tar.xz) = 1928540 bytes
 SHA1 (patch-Local_Makefile.pkgsrc) = 7d6971cfe6f6fecf854926e90460b1a8bcd6a79d
 SHA1 (patch-OS_Makefile-Default) = 6af17f036ed02a3bc37c1f303269eea447fcb691
 SHA1 (patch-lookups_Makefile) = cfc40dba3f75ef37b9887f7767139ad50cf9d4e5

--- a/mail/exim/patches/patch-Local_Makefile.pkgsrc
+++ b/mail/exim/patches/patch-Local_Makefile.pkgsrc
@@ -1,5 +1,7 @@
 $NetBSD: patch-Local_Makefile.pkgsrc,v 1.2 2019/12/09 18:46:00 adam Exp $
 
+Avoid hardcoded paths.
+
 --- Local/Makefile.pkgsrc.orig	2019-12-09 08:46:14.000000000 +0000
 +++ Local/Makefile.pkgsrc
 @@ -100,7 +100,7 @@

--- a/mail/exim/patches/patch-OS_Makefile-Default
+++ b/mail/exim/patches/patch-OS_Makefile-Default
@@ -1,5 +1,7 @@
 $NetBSD: patch-OS_Makefile-Default,v 1.1 2017/03/18 07:08:23 adam Exp $
 
+Avoid hardcoding a compiler, also honour LDFLAGS from environment.
+
 --- OS/Makefile-Default.orig	2012-05-31 00:40:15.000000000 +0000
 +++ OS/Makefile-Default
 @@ -71,7 +71,7 @@ PERL_COMMAND=/usr/bin/perl


### PR DESCRIPTION
This is a security release, addressing CVE-2025-26794