### PR TITLE
mk: Use bsdtar on OpenBSD

### DIFF
--- a/mk/platform/OpenBSD.mk
+++ b/mk/platform/OpenBSD.mk
@@ -12,6 +12,9 @@ PS?=		/bin/ps
 SU?=		/usr/bin/su
 TYPE?=		type				# Shell builtin
 
+# Native tar does not support --strip-components
+EXTRACT_USING?= bsdtar
+
 .if exists(/usr/sbin/user)
 USERADD?=	/usr/sbin/useradd
 GROUPADD?=	/usr/sbin/groupadd


### PR DESCRIPTION
Native tar does not support --strip-components