### PR TITLE
vsearch: Update to 2.30.0

### DIFF
--- a/biology/vsearch/Makefile
+++ b/biology/vsearch/Makefile
@@ -1,6 +1,6 @@
-# $NetBSD: Makefile,v 1.11 2024/10/21 20:26:13 bacon Exp $
+# $NetBSD$
 
-DISTNAME=	vsearch-2.29.0
+DISTNAME=	vsearch-2.30.0
 CATEGORIES=	biology
 MASTER_SITES=	${MASTER_SITE_GITHUB:=torognes/}
 GITHUB_TAG=	v${PKGVERSION_NOREV}

--- a/biology/vsearch/PLIST
+++ b/biology/vsearch/PLIST
@@ -1,3 +1,3 @@
-@comment $NetBSD: PLIST,v 1.10 2024/10/21 20:26:13 bacon Exp $
+@comment $NetBSD$
 bin/vsearch
 man/man1/vsearch.1

--- a/biology/vsearch/distinfo
+++ b/biology/vsearch/distinfo
@@ -1,5 +1,6 @@
-$NetBSD: distinfo,v 1.13 2024/10/21 20:26:13 bacon Exp $
+$NetBSD$
 
-BLAKE2s (vsearch-2.29.0.tar.gz) = 9161d18496922e627348951236680c827fefc7590170917005f89bd60f501715
-SHA512 (vsearch-2.29.0.tar.gz) = 75d67c667d2c30950bef83dbbf2486330fea1cd5b51d3e54f1f86cc7e92c74974dce596a61a55779c6819069d4220bdb31a76c6fa374a8298fa535b8d3c9ee48
-Size (vsearch-2.29.0.tar.gz) = 283459 bytes
+BLAKE2s (vsearch-2.30.0.tar.gz) = 7962abb52ecbe438eba885afd04ff6bfa8c3c45de741efb34fdd9360d3c4bdad
+SHA512 (vsearch-2.30.0.tar.gz) = f3e74ec3ff3831dd70117d1cbfacd693fc7d89b8fa19dccc3fe863655fd3304d1ce3a960ba8369ec73a45b0b0efcb796ce627d37cfe113912872eb7fbb0d99a1
+Size (vsearch-2.30.0.tar.gz) = 285775 bytes
+SHA1 (patch-src_vsearch.h) = 6e9a21883a2bb7a54d8550fa0eaf8b1ae1767ec0

--- a/biology/vsearch/patches/patch-src_vsearch.h
+++ b/biology/vsearch/patches/patch-src_vsearch.h
@@ -1,0 +1,16 @@
+$NetBSD$
+
+# libsysinfo not available in dreckly yet
+
+--- src/vsearch.h.orig	2025-03-02 14:06:13.019197000 +0000
++++ src/vsearch.h
+@@ -163,7 +163,8 @@
+ #elif __FreeBSD__
+ 
+ #define PROG_OS "freebsd"
+-#include <sys/sysinfo.h>
++// Only available via FreeBSD ports at this time
++// #include <sys/sysinfo.h>
+ #include <sys/resource.h>
+ #include <sys/endian.h>
+ #define bswap_16(x) bswap16(x)


### PR DESCRIPTION
Add options --n_mismatch, --fastq_minqual, and --fastq_truncee_rate Changes: https://github.com/torognes/vsearch/releases