### PR TITLE
mk: Introduce and use MASTER_SITE_GNUPG

### DIFF
--- a/mk/fetch/sites.mk
+++ b/mk/fetch/sites.mk
@@ -26,6 +26,12 @@ MASTER_SITE_GITLAB+=	\
 MASTER_SITE_GNUSTEP+=   \
 	ftp://ftp.gnustep.org/pub/gnustep/
 
+MASTER_SITE_GNUPG+=	\
+	https://mirrors.dotsrc.org/gcrypt/ \
+	https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/ \
+	http://gnupg.org/ftp/gcrypt/ \
+	http://www.ring.gr.jp/pub/net/gnupg/
+
 MASTER_SITE_OSDN+=	\
 	http://jaist.dl.osdn.jp/ \
 	http://iij.dl.osdn.jp/ \

--- a/security/gnu-crypto/Makefile
+++ b/security/gnu-crypto/Makefile
@@ -5,7 +5,7 @@ DISTNAME=		gnu-crypto-2.0.1-bin
 PKGNAME=		${DISTNAME:S/-bin$//}
 PKGREVISION=		1
 CATEGORIES=		security
-MASTER_SITES=		ftp://ftp.gnupg.org/GnuPG/gnu-crypto/
+MASTER_SITES=		${MASTER_SITE_GNUPG:=gnu-crypto/}
 EXTRACT_SUFX=		.tar.bz2
 
 MAINTAINER=		pkgsrc-users@NetBSD.org

--- a/security/gnupg/Makefile
+++ b/security/gnupg/Makefile
@@ -3,8 +3,7 @@
 DISTNAME=	gnupg-1.4.23
 PKGREVISION=	23
 CATEGORIES=	security
-MASTER_SITES=	ftp://ftp.gnupg.org/gcrypt/gnupg/
-MASTER_SITES+=	ftp://ftp.ring.gr.jp/pub/net/gnupg/gnupg/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=gnupg/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/security/gnupg2/Makefile
+++ b/security/gnupg2/Makefile
@@ -3,8 +3,7 @@
 DISTNAME=	gnupg-2.4.7
 PKGNAME=	${DISTNAME:S/gnupg-/gnupg2-/}
 CATEGORIES=	security
-MASTER_SITES=	https://gnupg.org/ftp/gcrypt/gnupg/
-MASTER_SITES+=	http://mirrors.dotsrc.org/gcrypt/gnupg/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=gnupg/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	ada@netbsdfr.org

--- a/security/gnutls/Makefile
+++ b/security/gnutls/Makefile
@@ -2,7 +2,7 @@
 
 DISTNAME=	gnutls-3.8.9
 CATEGORIES=	security devel
-MASTER_SITES=	https://www.gnupg.org/ftp/gcrypt/gnutls/v${PKGVERSION_NOREV:R}/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=gnutls/v${PKGVERSION_NOREV:R}/}
 EXTRACT_SUFX=	.tar.xz
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/security/gpa/Makefile
+++ b/security/gpa/Makefile
@@ -3,7 +3,7 @@
 DISTNAME=	gpa-0.10.0
 PKGREVISION=	14
 CATEGORIES=	x11 security
-MASTER_SITES=	ftp://ftp.gnupg.org/gcrypt/gpa/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=gpa/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pr@alles.prima.de

--- a/security/gpgme/Makefile
+++ b/security/gpgme/Makefile
@@ -2,7 +2,7 @@
 
 DISTNAME=	gpgme-1.24.1
 CATEGORIES=	security
-MASTER_SITES=	https://www.gnupg.org/ftp/gcrypt/gpgme/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=gpgme/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/security/libassuan2/Makefile
+++ b/security/libassuan2/Makefile
@@ -2,8 +2,7 @@
 
 DISTNAME=	libassuan-3.0.1
 CATEGORIES=	security
-MASTER_SITES=	ftp://ftp.gnupg.org/gcrypt/libassuan/
-MASTER_SITES+=	http://mirrors.dotsrc.org/gcrypt/libassuan/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=libassuan/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/security/libgcrypt/Makefile
+++ b/security/libgcrypt/Makefile
@@ -3,7 +3,7 @@
 DISTNAME=	libgcrypt-1.11.0
 PKGREVISION=	2
 CATEGORIES=	security
-MASTER_SITES=	https://gnupg.org/ftp/gcrypt/libgcrypt/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=libgcrypt/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org
@@ -14,7 +14,7 @@ LICENSE=	gnu-gpl-v2 AND gnu-lgpl-v2.1
 USE_LIBTOOL=		yes
 GNU_CONFIGURE=		yes
 TEST_TARGET=		check
-TEXINFO_REQD=		4.0
+TEXINFO_REQD+=		4.0
 INFO_FILES=		yes
 
 .include "../../mk/compiler.mk"
@@ -45,8 +45,8 @@ CONFIGURE_ARGS+=	CC_FOR_BUILD=${NATIVE_CC:Q}
 # dependencies like libgcrypt.  I don't see a way to use pkg-config or
 # anything reasonable to override this, so, we do the nonsense thing
 # instead.
-CONFIGURE_ARGS+=	GPGRT_CONFIG=${CROSS_DESTDIR:Q}${LOCALBASE}/bin/gpgrt-config
-CONFIGURE_ARGS+=	GPG_ERROR_CONFIG=${CROSS_DESTDIR:Q}${LOCALBASE}/bin/gpg-error-config
+CONFIGURE_ARGS+=	GPGRT_CONFIG=${CROSS_DESTDIR:Q}${PREFIX}/bin/gpgrt-config
+CONFIGURE_ARGS+=	GPG_ERROR_CONFIG=${CROSS_DESTDIR:Q}${PREFIX}/bin/gpg-error-config
 .endif
 
 .if ${OPSYS} == "Darwin"

--- a/security/libgcrypt/options.mk
+++ b/security/libgcrypt/options.mk
@@ -4,9 +4,9 @@ PKG_OPTIONS_VAR=	PKG_OPTIONS.libgcrypt
 PKG_SUPPORTED_OPTIONS=
 
 .include "../../mk/bsd.prefs.mk"
+.include "../../mk/compiler.mk"
 
 .if ${MACHINE_ARCH} == "i386" && ${OPSYS} != "Darwin"
-.  include "../../mk/compiler.mk"
 # GCC 3.x (at least 3.3.3 on NetBSD) fails to compile asm() call in
 # cipher/rijndael.c:do_padlock()
 .  if !${CC_VERSION:Mgcc-3.*}

--- a/security/libgpg-error/Makefile
+++ b/security/libgpg-error/Makefile
@@ -2,9 +2,7 @@
 
 DISTNAME=	libgpg-error-1.51
 CATEGORIES=	security
-MASTER_SITES=	https://www.gnupg.org/ftp/gcrypt/libgpg-error/
-MASTER_SITES+=	ftp://ftp.gnupg.org/gcrypt/libgpg-error/
-MASTER_SITES+=	ftp://ftp.ring.gr.jp/pub/net/gnupg/libgpg-error/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=libgpg-error/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	minskim@NetBSD.org

--- a/security/libksba/Makefile
+++ b/security/libksba/Makefile
@@ -2,7 +2,7 @@
 
 DISTNAME=	libksba-1.6.7
 CATEGORIES=	security
-MASTER_SITES=	ftp://ftp.gnupg.org/gcrypt/libksba/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=libksba/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org

--- a/security/qgpgme/Makefile
+++ b/security/qgpgme/Makefile
@@ -4,7 +4,7 @@ DISTNAME=	gpgme-1.23.2
 PKGNAME=	qgpgme-1.23.2
 PKGREVISION=	6
 CATEGORIES=	security
-MASTER_SITES=	ftp://ftp.gnupg.org/gcrypt/gpgme/
+MASTER_SITES=	${MASTER_SITE_GNUPG:=gpgme/}
 EXTRACT_SUFX=	.tar.bz2
 
 MAINTAINER=	pkgsrc-users@NetBSD.org


### PR DESCRIPTION
There is currently a mess of different MASTER_SITES for gnupg packages, centralize it.