### PR TITLE
fasda-utils: FASDA optional tools

### DIFF
--- a/biology/Makefile
+++ b/biology/Makefile
@@ -28,6 +28,7 @@ SUBDIR+=	clustalw
 SUBDIR+=	coalesce
 SUBDIR+=	coordgenlibs
 SUBDIR+=	fasda
+SUBDIR+=	fasda-utils
 SUBDIR+=	fastDNAml
 SUBDIR+=	fastp
 SUBDIR+=	fastq-trim

--- a/biology/fasda-utils/DESCR
+++ b/biology/fasda-utils/DESCR
@@ -1,0 +1,9 @@
+FASDA aims to provide a fast and simple differential analysis tool
+that just works and does not require any knowledge beyond basic
+Unix command-line skills. The code is written entirely in C to
+maximize efficiency and portability, and to provide a simple
+command-line user interface.
+
+FASDA-utils is a collection of optional companion programs and
+scripts.  They are separated from the main FASDA distribution in
+order to keep FASDA packages minimal.

--- a/biology/fasda-utils/Makefile
+++ b/biology/fasda-utils/Makefile
@@ -1,0 +1,20 @@
+# $NetBSD$
+
+DISTNAME=	fasda-utils-0.1.0
+CATEGORIES=	biology
+MASTER_SITES=	${MASTER_SITE_GITHUB:=auerlab/}
+
+OWNER=		bacon@NetBSD.org
+HOMEPAGE=	https://github.com/auerlab/fasda-utils
+COMMENT=	Fast and simple differential analysis extras
+LICENSE=	2-clause-bsd
+
+DEPENDS+=	${PYPKGPREFIX}-seaborn>0:../../graphics/py-seaborn
+DEPENDS+=	${PYPKGPREFIX}-fastcluster>0:../../math/py-fastcluster
+
+REPLACE_PYTHON=	Scripts/heatmap.py
+
+MAKE_FLAGS+=	MANDIR=${PREFIX}/${PKGMANDIR} VERSION=${PKGVERSION}
+
+.include "../../lang/python/application.mk"
+.include "../../mk/bsd.pkg.mk"

--- a/biology/fasda-utils/PLIST
+++ b/biology/fasda-utils/PLIST
@@ -1,0 +1,4 @@
+@comment $NetBSD$
+libexec/fasda/heatmap
+libexec/fasda/heatmap.py
+man/man1/fasda-heatmap.1

--- a/biology/fasda-utils/distinfo
+++ b/biology/fasda-utils/distinfo
@@ -1,0 +1,5 @@
+$NetBSD$
+
+BLAKE2s (fasda-utils-0.1.0.tar.gz) = 925d65eeaf2c8df07e090a1099596294bc1f7fa89223c3574358871106103dda
+SHA512 (fasda-utils-0.1.0.tar.gz) = fccfb20e741746a39dc34c1fb2524e36bfa758199c973e7de7f5fb3d85629cb461249845aac45c92252998da34baab270af56acfca74d98f46277c1adddc121a
+Size (fasda-utils-0.1.0.tar.gz) = 4891 bytes


### PR DESCRIPTION
FASDA aims to provide a fast and simple differential analysis tool
that just works and does not require any knowledge beyond basic
Unix command-line skills. The code is written entirely in C to
maximize efficiency and portability, and to provide a simple
command-line user interface.

FASDA-utils is a collection of optional companion programs and
scripts.  They are separated from the main FASDA distribution in
order to keep FASDA packages minimal.