### PR TITLE
oils-for-unix: Initial import

### DIFF
--- a/shells/oils-for-unix/DESCR
+++ b/shells/oils-for-unix/DESCR
@@ -1,0 +1,4 @@
+Oils is a Unix shell with JSON-compatible structured data. It's our upgrade path from bash to a better language and runtime.
+
+bin/osh runs POSIX shell scripts and many bash scripts. bin/ysh is an improved shell language.
+

--- a/shells/oils-for-unix/DESCR
+++ b/shells/oils-for-unix/DESCR
@@ -1,4 +1,6 @@
-Oils is a Unix shell with JSON-compatible structured data. It's our upgrade path from bash to a better language and runtime.
+Oils is a Unix shell with JSON-compatible structured data. It's our
+upgrade path from bash to a better language and runtime.
 
-bin/osh runs POSIX shell scripts and many bash scripts. bin/ysh is an improved shell language.
+bin/osh runs POSIX shell scripts and many bash scripts. bin/ysh is an
+improved shell language.
 

--- a/shells/oils-for-unix/Makefile
+++ b/shells/oils-for-unix/Makefile
@@ -21,10 +21,13 @@ PKG_SUPPORTED_OPTIONS=	readline
 .include "../../mk/bsd.options.mk"
 
 .if !empty(PKG_OPTIONS:Mreadline)
+.if ${OPSYS} == "OpenBSD"
+BUILDLINK_TRANSFORM+= l:readline:ereadline:ehistory
+.endif
 .include "../../devel/readline/buildlink3.mk"
-CONFIGURE_ARGS+=	--with-readline
-READLINE_DIR=		${BUILDLINK_PREFIX.readline}
-CONFIGURE_ARGS+=	--readline ${READLINE_DIR}
+CONFIGURE_ARGS+=		--with-readline
+READLINE_DIR=			${BUILDLINK_PREFIX.readline}
+CONFIGURE_ARGS+=		--readline ${READLINE_DIR}
 .endif
 
 do-build:

--- a/shells/oils-for-unix/Makefile
+++ b/shells/oils-for-unix/Makefile
@@ -1,0 +1,36 @@
+# $NetBSD$
+
+DISTNAME=	oils-for-unix-0.31.0
+CATEGORIES=	shells
+MASTER_SITES=	https://oils.pub/download/
+
+MAINTAINER=	marc@coquand.email
+HOMEPAGE=	https://oils.pub/download/
+COMMENT=	Oils is a Unix shell with JSON-compatible structured data. 
+LICENSE=	apache-2.0
+
+GNU_CONFIGURE=	yes
+USE_LANGUAGES=	c c++
+
+PKG_SHELL=	/bin/osh
+PKG_SHELL+=	/bin/ysh
+
+PKG_OPTIONS_VAR=	PKG_OPTIONS.oils-for-unix
+PKG_SUPPORTED_OPTIONS=	readline
+
+.include "../../mk/bsd.options.mk"
+
+.if !empty(PKG_OPTIONS:Mreadline)
+.include "../../devel/readline/buildlink3.mk"
+CONFIGURE_ARGS+=	--with-readline
+READLINE_DIR=		${BUILDLINK_PREFIX.readline}
+CONFIGURE_ARGS+=	--readline ${READLINE_DIR}
+.endif
+
+do-build:
+	cd ${WRKSRC} && _build/oils.sh
+
+do-install:
+	cd ${WRKSRC} && DESTDIR=${DESTDIR} ./install
+
+.include "../../mk/bsd.pkg.mk"

--- a/shells/oils-for-unix/PLIST
+++ b/shells/oils-for-unix/PLIST
@@ -1,0 +1,5 @@
+@comment $NetBSD$
+bin/oils-for-unix
+bin/osh
+bin/ysh
+share/man/man1/osh.1

--- a/shells/oils-for-unix/distinfo
+++ b/shells/oils-for-unix/distinfo
@@ -1,0 +1,5 @@
+$NetBSD$
+
+BLAKE2s (oils-for-unix-0.31.0.tar.gz) = ecc5ff2bf6ce4f5dbfbfa79d42cdb1d0c518bbcf3fa9d23e8e2812197f4baade
+SHA512 (oils-for-unix-0.31.0.tar.gz) = 8d4b4a46a6a83a7035b77a8977be398d58be409b46dc4e183f4f3aaf308e284eda62e4cc841769defbfb68ddb3081c2511f75bb877cd67f169f29fb4a3df6f05
+Size (oils-for-unix-0.31.0.tar.gz) = 855925 bytes


### PR DESCRIPTION
Adds oils for unix: https://oils.pub/

So far I've tested it on Freebsd 14.3 with and without readline support and it worked fine. 