### PR TITLE
minimap2: Update to 2.30

### DIFF
--- a/biology/minimap2/Makefile
+++ b/biology/minimap2/Makefile
@@ -1,6 +1,6 @@
 # $NetBSD: Makefile,v 1.4 2023/08/14 05:23:51 wiz Exp $
 
-VERSION=	2.29
+VERSION=	2.30
 DISTNAME=	minimap2-${VERSION}
 CATEGORIES=	biology python
 MASTER_SITES=	${MASTER_SITE_GITHUB:=lh3/}
@@ -13,14 +13,11 @@ LICENSE=	mit
 
 USE_TOOLS+=	gmake
 MAKE_FILE=	Makefile.simde
+BUILD_TARGET=	extra
 
 CFLAGS+=	-DHAVE_KALLOC
 
 INSTALLATION_DIRS+=	bin ${PKGMANDIR}/man1
-
-do-install:
-	${INSTALL} ${WRKSRC}/minimap2 ${DESTDIR}${PREFIX}/bin
-	${INSTALL_DATA} ${WRKSRC}/minimap2.1 ${DESTDIR}${PREFIX}/${PKGMANDIR}/man1
 
 .include "../../devel/zlib/buildlink3.mk"
 .include "../../devel/simde/buildlink3.mk"

--- a/biology/minimap2/PLIST
+++ b/biology/minimap2/PLIST
@@ -1,3 +1,14 @@
 @comment $NetBSD$
 bin/minimap2
+bin/minimap2-lite
+bin/sdust
 man/man1/minimap2.1
+share/minimap2/test/MT-human.fa
+share/minimap2/test/MT-orang.fa
+share/minimap2/test/q-inv.fa
+share/minimap2/test/q2.fa
+share/minimap2/test/t-inv.fa
+share/minimap2/test/t2.fa
+share/minimap2/test/x3s-aln.txt
+share/minimap2/test/x3s-qry.fa
+share/minimap2/test/x3s-ref.fa

--- a/biology/minimap2/distinfo
+++ b/biology/minimap2/distinfo
@@ -1,7 +1,7 @@
 $NetBSD$
 
-BLAKE2s (minimap2-2.29.tar.gz) = 9db51992b4fe24f57a1363d28c2ccb393abd59949543b711902dd1c178e6690e
-SHA512 (minimap2-2.29.tar.gz) = 5f299cf9a268fab2e58fb915ffac139bfc95b237da0dc084298ff085e39e064e8ffa3f4c1d9f7275feefa917ccded6c9e32a8306558a3fe29a3085581f93c69d
-Size (minimap2-2.29.tar.gz) = 269107 bytes
-SHA1 (patch-Makefile.simde) = 599fd3841a1d7c628c759fb6546dc985bb36a5a7
+BLAKE2s (minimap2-2.30.tar.gz) = d2943e62ef67cf1fb68665bacc9ae56b17950b55523e8fea03ad85168b05f468
+SHA512 (minimap2-2.30.tar.gz) = ea2159021b878d7811111c14bb4da28fee7208242c67159b14f5ba9bc83fb312d5bf8c0abe54d7011b854fae7c8b21b54a8e04c15915510dc8a01fa1b4362650
+Size (minimap2-2.30.tar.gz) = 269912 bytes
+SHA1 (patch-Makefile.simde) = fe893154d233e0b4cac679c40d40838ca83a6183
 SHA1 (patch-example.c) = ccf0c4addfece2e11b90f5a558a6de324f255d7c

--- a/biology/minimap2/patches/patch-Makefile.simde
+++ b/biology/minimap2/patches/patch-Makefile.simde
@@ -2,7 +2,7 @@ $NetBSD$
 
 # Respect standard env vars
 
---- Makefile.simde.orig	2025-04-18 17:41:47.000000000 +0000
+--- Makefile.simde.orig	2025-06-15 21:54:11.000000000 +0000
 +++ Makefile.simde
 @@ -1,12 +1,25 @@
 -CFLAGS=		-g -Wall -O2 -Wc++-compat #-Wextra
@@ -55,7 +55,7 @@ $NetBSD$
  .SUFFIXES:.c .o
  
  .c.o:
-@@ -37,10 +50,10 @@ all:$(PROG)
+@@ -37,16 +50,16 @@ all:$(PROG)
  extra:all $(PROG_EXTRA)
  
  minimap2:main.o libminimap2.a
@@ -68,6 +68,13 @@ $NetBSD$
  
  libminimap2.a:$(OBJS)
  		$(AR) -csru $@ $(OBJS)
+ 
+ sdust:sdust.c kalloc.o kalloc.h kdq.h kvec.h kseq.h ketopt.h sdust.h
+-		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ -lz
++		$(CC) -D_SDUST_MAIN $(CFLAGS) $< kalloc.o -o $@ $(LDFLAGS)
+ 
+ ksw2_ll_simde.o:ksw2_ll_sse.c ksw2.h kalloc.h
+ 		$(CC) -c $(CFLAGS) -msse2 $(CPPFLAGS) $(INCLUDES) $< -o $@
 @@ -60,8 +73,27 @@ ksw2_extd2_simde.o:ksw2_extd2_sse.c ksw2
  ksw2_exts2_simde.o:ksw2_exts2_sse.c ksw2.h kalloc.h
  		$(CC) -c $(CFLAGS) -msse4.1 $(CPPFLAGS) $(INCLUDES) $< -o $@


### PR DESCRIPTION
Deprecate several subcommands, replaced by minigff
Changes: https://github.com/lh3/minimap2/releases